### PR TITLE
Fix circular imports

### DIFF
--- a/packages/memory_module/__init__.py
+++ b/packages/memory_module/__init__.py
@@ -1,0 +1,16 @@
+from memory_module.config import LLMConfig, MemoryModuleConfig
+from memory_module.core.memory_module import MemoryModule
+from memory_module.interfaces.types import (
+    Memory,
+    Message,
+    ShortTermMemoryRetrievalConfig,
+)
+
+__all__ = [
+    "MemoryModule",
+    "MemoryModuleConfig",
+    "LLMConfig",
+    "Memory",
+    "Message",
+    "ShortTermMemoryRetrievalConfig",
+]

--- a/packages/memory_module/core/memory_core.py
+++ b/packages/memory_module/core/memory_core.py
@@ -7,11 +7,11 @@ from pydantic import BaseModel, Field
 
 from memory_module.config import MemoryModuleConfig
 from memory_module.interfaces.base_memory_core import BaseMemoryCore
+from memory_module.interfaces.base_memory_storage import BaseMemoryStorage
 from memory_module.interfaces.types import EmbedText, Memory, MemoryType, Message, ShortTermMemoryRetrievalConfig
 from memory_module.services.llm_service import LLMService
+from memory_module.storage.in_memory_storage import InMemoryStorage
 from memory_module.storage.sqlite_memory_storage import SQLiteMemoryStorage
-from packages.memory_module.interfaces.base_memory_storage import BaseMemoryStorage
-from packages.memory_module.storage.in_memory_storage import InMemoryStorage
 
 logger = logging.getLogger(__name__)
 

--- a/packages/memory_module/core/message_buffer.py
+++ b/packages/memory_module/core/message_buffer.py
@@ -6,8 +6,8 @@ from memory_module.interfaces.base_message_buffer_storage import BaseMessageBuff
 from memory_module.interfaces.base_scheduled_events_service import BaseScheduledEventsService
 from memory_module.interfaces.types import Message
 from memory_module.services.scheduled_events_service import ScheduledEventsService
+from memory_module.storage.in_memory_storage import InMemoryStorage
 from memory_module.storage.sqlite_message_buffer_storage import SQLiteMessageBufferStorage
-from packages.memory_module.storage.in_memory_storage import InMemoryStorage
 
 
 class MessageBuffer:

--- a/packages/memory_module/services/scheduled_events_service.py
+++ b/packages/memory_module/services/scheduled_events_service.py
@@ -9,8 +9,8 @@ from memory_module.interfaces.base_scheduled_events_service import (
     Event,
 )
 from memory_module.interfaces.base_scheduled_events_storage import BaseScheduledEventsStorage
+from memory_module.storage.in_memory_storage import InMemoryStorage
 from memory_module.storage.sqlite_scheduled_events_storage import SQLiteScheduledEventsStorage
-from packages.memory_module.storage.in_memory_storage import InMemoryStorage
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
I was accidentally doing packages.memory_module that was messing up imports (and using __init__.py)