### PR TITLE
Fix evals dependency issue

### DIFF
--- a/packages/evals/pyproject.toml
+++ b/packages/evals/pyproject.toml
@@ -5,14 +5,12 @@ description = "Benchmarks for the different components"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "memory-module"
-]
-
-[tool.uv]
-package = false
-dev-dependencies = [
+    "memory-module",
     "pandas",
     "mlflow>=2.17.2",
     "tqdm>=4.66.5",
     "databricks-sdk",
 ]
+
+[tool.uv]
+package = false

--- a/packages/memory_module/pyproject.toml
+++ b/packages/memory_module/pyproject.toml
@@ -15,6 +15,5 @@ dependencies = [
     "botbuilder>=0.0.1",
 ]
 
-[tool.uv]
-dev-dependencies = []
-
+[dependency-groups]
+dev = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,9 @@ dependencies = ["agent-runtime", "memory-module", "litellm", "evals"]
 
 [tool.uv]
 package = false
-dev-dependencies = [
+
+[dependency-groups]
+dev = [
     "poethepoet>=0.28.0",
     "pre-commit>=4.0.1",
     "pytest-asyncio>=0.24.0",

--- a/uv.lock
+++ b/uv.lock
@@ -631,23 +631,17 @@ name = "evals"
 version = "0.1.0"
 source = { virtual = "packages/evals" }
 dependencies = [
-    { name = "memory-module" },
-]
-
-[package.dev-dependencies]
-dev = [
     { name = "databricks-sdk" },
+    { name = "memory-module" },
     { name = "mlflow" },
     { name = "pandas" },
     { name = "tqdm" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "memory-module", virtual = "packages/memory_module" }]
-
-[package.metadata.requires-dev]
-dev = [
+requires-dist = [
     { name = "databricks-sdk" },
+    { name = "memory-module", virtual = "packages/memory_module" },
     { name = "mlflow", specifier = ">=2.17.2" },
     { name = "pandas" },
     { name = "tqdm", specifier = ">=4.66.5" },
@@ -1318,6 +1312,9 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "sqlite-vec", specifier = ">=0.1.6" },
 ]
+
+[package.metadata.requires-dev]
+dev = []
 
 [[package]]
 name = "mlflow"


### PR DESCRIPTION
- When using `uv` v0.5.x, `dev-dependencies` in the evals/`pyproject.toml` weren't being picked up by `uv sync`. Since it's a dev package, the dependencies have been moved to the `project.dependencies` list.
- Replaced `project.dev-dependencies` with `dependency-group` tables in the pyproject.toml files since the [former is being deprecated](https://docs.astral.sh/uv/concepts/projects/dependencies/#legacy-dev-dependencies) by uv.