### PR TITLE
Improve llm_service completions typings

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,7 @@
 # Summary of PR
 
 <!---
-Did you test your code? Unit tests? Manual testing?
+Describe the changes you made in a few sentences.
 -->
 
 # Details

--- a/packages/teams_memory/CHANGELOG.md
+++ b/packages/teams_memory/CHANGELOG.md
@@ -3,10 +3,13 @@
 ## Latest Changes
 
 ### Features
-- Added method `BaseMemoryModule.get_memories_with_attributions` to easily get the messages associated to memories. 
+
+- Added method `BaseMemoryModule.get_memories_with_attributions` to easily get the messages associated to memories.
 
 ### Bug Fixes
+
 - Tech assistant sample changes: fixed a bug, refactored citations, updated it to use python's logger library.
+- Update the way we build the litellm client for better typings
 
 ## 0.1.2-alpha
 

--- a/packages/teams_memory/teams_memory/services/llm_service.py
+++ b/packages/teams_memory/teams_memory/services/llm_service.py
@@ -3,14 +3,16 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
-from typing import Any, List, Optional, Union, cast
+from typing import Any, List, Optional, TypeVar, Union, cast, overload
 
 import instructor
 import litellm
 from litellm import BaseModel, acompletion
-from litellm.types.utils import EmbeddingResponse
+from litellm.types.utils import EmbeddingResponse, ModelResponse
 
 from teams_memory.config import LLMConfig
+
+T = TypeVar("T", bound=BaseModel)
 
 
 class LLMService:
@@ -61,13 +63,31 @@ class LLMService:
             not in {"model", "api_key", "api_base", "api_version", "embedding_model"}
         }
 
+    @overload
     async def completion(
         self,
         messages: List,
-        response_model: Optional[type[BaseModel]] = None,
+        response_model: None = None,
         override_model: Optional[str] = None,
         **kwargs,
-    ):
+    ) -> ModelResponse: ...
+
+    @overload
+    async def completion(
+        self,
+        messages: List,
+        response_model: type[T],
+        override_model: Optional[str] = None,
+        **kwargs,
+    ) -> T: ...
+
+    async def completion(
+        self,
+        messages: List,
+        response_model: Optional[type[T]] = None,
+        override_model: Optional[str] = None,
+        **kwargs,
+    ) -> Union[ModelResponse, T]:
         """Generate completion from the model."""
         model = override_model or self.model
         if not model:

--- a/packages/teams_memory/teams_memory/services/llm_service.py
+++ b/packages/teams_memory/teams_memory/services/llm_service.py
@@ -7,7 +7,7 @@ from typing import Any, List, Optional, TypeVar, Union, cast, overload
 
 import instructor
 import litellm
-from litellm import BaseModel, acompletion
+from litellm import BaseModel
 from litellm.types.utils import EmbeddingResponse, ModelResponse
 
 from teams_memory.config import LLMConfig
@@ -52,7 +52,7 @@ class LLMService:
         self.embedding_model = config.embedding_model
 
         self.client = cast(
-            instructor.AsyncInstructor, instructor.from_litellm(acompletion)
+            instructor.AsyncInstructor, instructor.from_litellm(litellm.acompletion)
         )  # we need to cast this because acompletion is still a callable, even though it's awaitable
 
         # Get any additional kwargs from the config

--- a/tests/teams_memory/test_llm_service.py
+++ b/tests/teams_memory/test_llm_service.py
@@ -50,12 +50,24 @@ async def _return_arguments(**kwargs):
 
 @pytest.fixture()
 def mock_completion(monkeypatch):
-    client = mock.Mock()
-    router = mock.Mock()
-    monkeypatch.setattr(instructor, "patch", client)
-    monkeypatch.setattr(litellm, "Router", router)
+    mock_chat_create = mock.AsyncMock()
 
-    return client, router
+    MockClient = type(
+        "Client",
+        (),
+        {
+            "chat": type(
+                "Chat",
+                (),
+                {"completions": type("Completions", (), {"create": mock_chat_create})},
+            )
+        },
+    )
+    mock_client = mock.Mock()
+    mock_client.return_value = MockClient()
+    monkeypatch.setattr(instructor, "from_litellm", mock_client)
+
+    return mock_chat_create
 
 
 @pytest.fixture()
@@ -88,20 +100,16 @@ async def test_completion_calls_litellm_client(mock_completion):
 
     await lm.completion(messages, **local_args)
 
-    client_mock, router_mock = mock_completion
-    res = client_mock.mock_calls[1].kwargs
-    assert res["model"] == model
-    assert res["messages"] == messages
-    assert res["response_model"] is None
-    assert res["local test key"] == local_args["local test key"]
-
-    config = router_mock.mock_calls[0].kwargs["model_list"][0]
-    assert config["model_name"] == model
-    assert config["litellm_params"]["model"] == model
-    assert config["litellm_params"]["api_key"] == api_key
-    assert config["litellm_params"]["api_base"] == api_base
-    assert config["litellm_params"]["api_version"] == api_version
-    assert config["litellm_params"]["test key"] == litellm_params["test key"]
+    config = mock_completion.mock_calls[0].kwargs
+    assert config["model"] == model
+    assert config["messages"] == messages
+    assert config["local test key"] == local_args["local test key"]
+    assert config["response_model"] is None
+    assert config["model"] == model
+    assert config["api_key"] == api_key
+    assert config["api_base"] == api_base
+    assert config["api_version"] == api_version
+    assert config["test key"] == litellm_params["test key"]
 
 
 @pytest.mark.asyncio
@@ -139,7 +147,7 @@ async def test_completion_openai(config: EnvLLMConfig):
     if not config.openai_api_key:
         pytest.skip("OpenAI API key is missing")
 
-    llm_config = LLMConfig(model="gpt-4o", api_key=config.openai_api_key)
+    llm_config = LLMConfig(model="gpt-4o-mini", api_key=config.openai_api_key)
     lm = LLMService(config=llm_config)
     messages = [
         {"role": "system", "content": "Which country has a maple leaf in its flag?"}
@@ -335,8 +343,8 @@ async def test_completion_model_override(mock_completion):
 
     await lm.completion(messages=[], override_model=override_model)
 
-    client_mock, _ = mock_completion
-    res = client_mock.mock_calls[1].kwargs
+    completions_mock = mock_completion
+    res = completions_mock.mock_calls[0].kwargs
     assert res["model"] == override_model
 
 
@@ -350,8 +358,8 @@ async def test_completion_parameter_override(mock_completion):
 
     await lm.completion(messages=[], **override_params)
 
-    client_mock, _ = mock_completion
-    res = client_mock.mock_calls[1].kwargs
+    completions_mock = mock_completion
+    res = completions_mock.mock_calls[0].kwargs
 
     for key, value in override_params.items():
         assert res[key] == value

--- a/tests/teams_memory/test_llm_service.py
+++ b/tests/teams_memory/test_llm_service.py
@@ -338,3 +338,20 @@ async def test_completion_model_override(mock_completion):
     client_mock, _ = mock_completion
     res = client_mock.mock_calls[1].kwargs
     assert res["model"] == override_model
+
+
+@pytest.mark.asyncio
+async def test_completion_parameter_override(mock_completion):
+    model = "test-model"
+    override_params = {"temperature": 0.7, "max_tokens": 100, "top_p": 0.9}
+
+    llm_config = LLMConfig(model=model)
+    lm = LLMService(config=llm_config)
+
+    await lm.completion(messages=[], **override_params)
+
+    client_mock, _ = mock_completion
+    res = client_mock.mock_calls[1].kwargs
+
+    for key, value in override_params.items():
+        assert res[key] == value


### PR DESCRIPTION
# Summary of PR

In this PR, we update the way we create our client to be more reflective of the way that instructor wants us to do it (https://docs.litellm.ai/docs/tutorials/instructor). This removes our need for type ignores.

I also added better overrides so that if you call the completion function without `response_model` it would return `ModelResponse`, otherwise it would return `T`.

# Testing

Tested manually, and unit tests

# Checklist

- [x] I thought through documentation (and updated the docs if necessary)
- [x] I updated the CHANGELOG.md file (or have a good reason not to)
