### PR TITLE
Fix `configure_logging` bug

### DIFF
--- a/packages/teams_memory/CHANGELOG.md
+++ b/packages/teams_memory/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added method `BaseMemoryModule.get_memories_with_attributions` to easily get the messages associated to memories.
 - Turn on mypy strict mode and fix mypy errors
+- Fix bug where calling `configure_logging` multiple times would add multiple handlers
 
 ### Bug Fixes
 

--- a/packages/teams_memory/teams_memory/utils/logging.py
+++ b/packages/teams_memory/teams_memory/utils/logging.py
@@ -11,7 +11,17 @@ def configure_logging(logging_level: int = logging.DEBUG) -> None:
     logger = logging.getLogger(module_name)
     logger.setLevel(logging_level)
 
+    handler_name = "teams-memory-console"
+    handler = next(
+        (handler for handler in logger.handlers if handler.name == handler_name), None
+    )
+    # If handler already added, update logging level
+    if handler:
+        handler.setLevel(logging_level)
+        return
+
     handler = logging.StreamHandler()
+    handler.name = handler_name
     handler.setLevel(logging_level)
 
     formatter = DefaultFormatter(


### PR DESCRIPTION
# Summary of PR
If `configure_logging` is called twice, then two handlers will be added to the "teams_memory" logger. And so a single log statement (ex `logger.info("hi")` will be printed to the console twice.

This PR fixes that issue by checking if the "teams-memory-console" handler was already added to the logger.

# Checklist

- [x] I thought through documentation (and updated the docs if necessary)
- [x] I updated the CHANGELOG.md file (or have a good reason not to)
